### PR TITLE
swr: Fix build with autoconf

### DIFF
--- a/src/gallium/targets/dri/Makefile.am
+++ b/src/gallium/targets/dri/Makefile.am
@@ -83,6 +83,7 @@ include $(top_srcdir)/src/gallium/drivers/vc4/Automake.inc
 
 include $(top_srcdir)/src/gallium/drivers/softpipe/Automake.inc
 include $(top_srcdir)/src/gallium/drivers/llvmpipe/Automake.inc
+include $(top_srcdir)/src/gallium/drivers/swr/Automake.inc
 
 if HAVE_GALLIUM_STATIC_TARGETS
 


### PR DESCRIPTION
Add missing include to gallium/targets/dri/Makefile.am.