### PR TITLE
FIx build issues with scons

### DIFF
--- a/scons/llvm.py
+++ b/scons/llvm.py
@@ -191,7 +191,7 @@ def generate(env):
             if '-fno-rtti' in cxxflags:
                 env.Append(CXXFLAGS = ['-fno-rtti'])
 
-            components = ['engine', 'mcjit', 'bitwriter', 'x86asmprinter', 'mcdisassembler']
+            components = ['engine', 'mcjit', 'bitwriter', 'x86asmprinter', 'mcdisassembler', 'irreader']
 
             env.ParseConfig('llvm-config --libs ' + ' '.join(components))
             env.ParseConfig('llvm-config --ldflags')


### PR DESCRIPTION
Needed to link against `irreader` to resolve link issues with llvm 3.6.2 with GCC 4.8.4

JitManager.cpp:223: undefined reference to
`llvm::parseIR(llvm::MemoryBufferRef, llvm::SMDiagnostic&, llvm::LLVMContext&)'