### PR TITLE
Remove numa.h header that don't seem to be used.

### DIFF
--- a/src/gallium/drivers/swr/rasterizer/core/api.cpp
+++ b/src/gallium/drivers/swr/rasterizer/core/api.cpp
@@ -30,10 +30,6 @@
 #include <cmath>
 #include <cstdio>
 
-#if defined(__gnu_linux__) || defined(__linux__)
-#include <numa.h>
-#endif
-
 #include "core/api.h"
 #include "core/backend.h"
 #include "core/context.h"

--- a/src/gallium/drivers/swr/rasterizer/core/threads.cpp
+++ b/src/gallium/drivers/swr/rasterizer/core/threads.cpp
@@ -32,7 +32,6 @@
 #include <string>
 
 #if defined(__linux__) || defined(__gnu_linux__)
-#include <numa.h>
 #include <pthread.h>
 #include <sched.h>
 #include <unistd.h>


### PR DESCRIPTION
These don't seem to be used currently. Makes it a little easier to build.